### PR TITLE
[v0.1.2] Update `cluster` module. Addresses #46

### DIFF
--- a/resources/tutorial/snekmer_demo.ipynb
+++ b/resources/tutorial/snekmer_demo.ipynb
@@ -2039,7 +2039,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.2"
   }
  },
  "nbformat": 4,

--- a/snekmer/__init__.py
+++ b/snekmer/__init__.py
@@ -10,4 +10,4 @@ from . import cluster
 
 # from . import walk
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/snekmer/transform.py
+++ b/snekmer/transform.py
@@ -478,7 +478,7 @@ def vectorize_string(
     start, end = set_sequence_endpoints(sequence, k, start, end)
 
     results = feature_dict or {}
-    if filter_list:
+    if filter_list is not None:
         results = {key: 0 for key in filter_list}
 
     for i in range(start, end):
@@ -494,7 +494,9 @@ def vectorize_string(
             print(f"{i}\t{k_map}\t{k_string}\t1",)
 
         # filter unrecognized characters or filter from list
-        if (len(k_string) < k) or (filter_list and k_string not in filter_list):
+        if (len(k_string) < k) or (
+            filter_list is not None and k_string not in filter_list
+        ):
             continue
 
         # FILTER HERE
@@ -508,7 +510,7 @@ def vectorize_string(
             results[k_string] = 0
         results[k_string] += 1
 
-    if filter_list:
+    if filter_list is not None:
         results = {item: results[item] for item in filter_list}
     if return_dict:
         return results

--- a/snekmer/utils.py
+++ b/snekmer/utils.py
@@ -243,7 +243,8 @@ def to_feature_matrix(array):
         2D array version of the 2D array-like input.
 
     """
-    return np.array([np.array(a, dtype=int) for a in array])
+    array = [np.array(a) for a in array]
+    return np.asarray(array)
 
 
 def str_to_array(array):

--- a/snekmer/vectorize.py
+++ b/snekmer/vectorize.py
@@ -3,10 +3,13 @@ author: @christinehc
 
 """
 import itertools
-import numpy as np
 from collections import Counter
-from snekmer.alphabets import ALPHABET, FULL_ALPHABETS, get_alphabet_keys, get_alphabet
-from typing import Union, Set
+from typing import Set, Union
+
+import numpy as np
+
+from snekmer.alphabets import ALPHABET, FULL_ALPHABETS, get_alphabet, get_alphabet_keys
+
 
 # generate all possible kmer combinations
 def _generate(alphabet: Union[str, int], k: int):
@@ -92,10 +95,7 @@ class KmerVec:
 
     # generate kmer vectors with bag-of-words approach
     def vectorize(self, sequence: str) -> np.ndarray:
-        #         self.char_set = set(ALPHABETS[alphabet]["_keys"])
         N = len(self.char_set) ** self.k
-        #         all_kmers = self._generate("".join(self.char_set), k)
-        #         self.kmers = list(self._generate(list(self.char_set), k))
 
         alphabet_map = get_alphabet(self.alphabet, mapping=FULL_ALPHABETS)
         sequence = self._reduce(sequence, alphabet_map=alphabet_map)


### PR DESCRIPTION
Clustering module has been updated to be fully compatible with previous code changes. Clustering now works locally.

Changes include:
- Full, explicit generation of all kmer combinations using itertools vs. slow/outdated `skm.utils.baseconvert` approach
- Reduction of workflow to remove unneeded kmer generation step
- Updates to input/output files to accommodate workflow changes listed above