### PR TITLE
[skip ci][bugfix] Fixed workflow-breaking bugs in cluster code

### DIFF
--- a/snekmer/__init__.py
+++ b/snekmer/__init__.py
@@ -9,4 +9,4 @@ from . import vectorize
 
 # from . import walk
 
-__version__ = "1.0.0-beta"
+__version__ = "1.0.1"

--- a/snekmer/io.py
+++ b/snekmer/io.py
@@ -47,7 +47,7 @@ def load_npz(
     columns: Dict[str, str] = {
         "ids": "sequence_id",
         "seqs": "sequence",
-        "vecs": "sequence_vector"
+        "vecs": "sequence_vector",
     },
 ) -> pd.DataFrame:
     """Compile .npz results into dataframe.
@@ -55,9 +55,9 @@ def load_npz(
     Parameters
     ----------
     filename : str
-        Description of parameter `filename`.
+        /path/to/filename for input .npz file.
     columns : Dict[str, str]
-        Description of parameter `columns` (the default is
+        Mapping for output data column names (the default is
             {
                 "ids": "sequence_id",
                 "seqs": "sequence",
@@ -68,17 +68,11 @@ def load_npz(
     Returns
     -------
     pd.DataFrame
-        Description of returned object.
-
-    Raises
-    ------
-    ExceptionName
-        Why the exception is raised.
+        Tabulated .npz data.
 
     """
     data = np.load(filename)
 
-    import time
     # fill in df based on desired output col names
     df = {"filename": splitext(basename(filename))[0]}
 
@@ -88,9 +82,9 @@ def load_npz(
         # get seq column for sequence lengths
         if "seq" in in_col:
             df.update({f"{out_col}_length": [len(s) for s in data[in_col]]})
-    # df.update()
 
-    return pd.DataFrame(df), data["kmerlist"]
+    return pd.DataFrame(df)
+
 
 def read_output_kmers(filename: str) -> List[str]:
     """Extract kmer identifiers from Snekmer output file.

--- a/snekmer/rules/cluster.smk
+++ b/snekmer/rules/cluster.smk
@@ -155,27 +155,27 @@ rule cluster:
         kmer = skm.io.load_pickle(input.kmerobj[0])
 
         # tabulate vectorized seq data
-        data = list()
-        kmerbasis = list()
-        kmerlists = list()
-        for f in input.data:
-            dat,kmerlist = skm.io.load_npz(f)
-            # memfix: these need to be harmonized
-            data.append(dat)
-            kmerlists.append(kmerlist)
-            kmerbasis.extend(kmerlist)
+        data, kmers = list(), list()
+        for dfile, kfile in zip(sorted(input.data), sorted(input.kmerobj)):
+            df = skm.io.load_npz(dfile)
+            data.append(df)
+
+            kobj = skm.io.load_pickle(kfile)
+            klist = kobj.kmer_set._kmerlist
+            kmers.append(klist)
+            # basis.extend(klist)
 
         # make a superset of kmers
-        kmerbasis = np.unique(kmerlist)
+        kmerbasis = np.unique(kmers)
         basis = skm.vectorize.KmerVec(config["alphabet"], config["k"])
         basis.set_kmer_set(kmerbasis)
 
         for i in range(len(data)):
-            this = data[i]
-            kmerlist = kmerlists[i]
-            vecs = skm.utils.to_feature_matrix(this["sequence_vector"].values)
-            that = basis.harmonize_data(vecs, kmerlist)
-            this["sequence_vector"] = that.tolist()
+            df, kmerlist = data[i], kmers[i]
+            vecs = skm.utils.to_feature_matrix(df["sequence_vector"].values)
+
+            converted = basis.harmonize(vecs, kmerlist)
+            df["sequence_vector"] = converted.tolist()
 
         data = pd.concat(data, ignore_index=True)
         data["background"] = [f in BGS for f in data["filename"]]

--- a/snekmer/vectorize.py
+++ b/snekmer/vectorize.py
@@ -102,7 +102,7 @@ class KmerBasis:
         # convert vector basis into set basis
         # we'll add a dummy column for all those that
         # aren't present in the input basis
-        unseen = ([0] * vector.shape[0])
+        unseen = [0] * vector.shape[0]
         vector = np.insert(vector, vector.shape[1], unseen, axis=1)
 
         i_convert = list()
@@ -111,7 +111,7 @@ class KmerBasis:
             if kmer in vector_basis_order:
                 idx = vector_basis_order[kmer]  # locate kmer in the new vector
             else:
-                idx = vector.shape[1]-1
+                idx = vector.shape[1] - 1
             i_convert.append(idx)
 
         return vector[:, i_convert]
@@ -134,7 +134,7 @@ class KmerSet:
     """Given alphabet and k, creates iterator for kmer basis set.
     """
 
-    def __init__(self, alphabet: Union[str, int], k: int, kmerlist: list=list()):
+    def __init__(self, alphabet: Union[str, int], k: int, kmerlist: list = list()):
         self.alphabet = alphabet
         self.k = k
 
@@ -180,6 +180,7 @@ def reduce(
     alphabet_map: Dict[str, str] = get_alphabet(alphabet, mapping=mapping)
     return sequence.translate(sequence.maketrans(alphabet_map))
 
+
 # memfix: this is to reformat a list of kmers coming from multiple sequences
 #         into a regular array and return that array and a list of the kmer
 #         order -
@@ -192,15 +193,15 @@ def make_feature_matrix(vecs, min_filter=1, max_filter=1):
     kmerlist, kmercounts = np.unique(kmerlist, return_counts=True)
 
     # filter based on counts
-    kmerlist = kmerlist[kmercounts>min_filter]
+    kmerlist = kmerlist[kmercounts > min_filter]
 
     nk = len(kmerlist)
-    #result = np.zeros(len(kmerlist)*len(vecs)).reshape(len(vecs),len(kmerlist))
+    # result = np.zeros(len(kmerlist)*len(vecs)).reshape(len(vecs),len(kmerlist))
 
     result = list()
     for i in range(len(vecs)):
         this = np.zeros(nk)
-        this[np.isin(kmerlist,vecs[i])] = 1
+        this[np.isin(kmerlist, vecs[i])] = 1
         result.append(this)
 
     return result, kmerlist
@@ -213,7 +214,7 @@ class KmerVec:
         self.char_set = get_alphabet_keys(alphabet)
         self.vector = None
         self.basis = KmerBasis()
-        #self.kmer_set = KmerSet(alphabet, k)
+        # self.kmer_set = KmerSet(alphabet, k)
 
     def set_kmer_set(self, kmer_set=list()):
         self.kmer_set = KmerSet(self.alphabet, self.k, kmer_set)
@@ -287,23 +288,23 @@ class KmerVec:
             Vector representation of sequence as reduced kmer vector.
 
         """
-        #N = len(self.char_set) ** self.k
+        # N = len(self.char_set) ** self.k
 
         reduced = reduce(sequence, alphabet=self.alphabet, mapping=FULL_ALPHABETS)
         kmers = list(self._kmer_gen(reduced))
-        #kmer2count = Counter(kmers)
+        # kmer2count = Counter(kmers)
 
         vector = np.array(kmers, dtype=str)
 
         # memfix change
         # this changes the output from a list to a dict
-        #vector = {}
-        #for kmer in kmers:
+        # vector = {}
+        # for kmer in kmers:
         #    vector[kmer] = 1
 
         # Convert to vector of counts
-        #vector = np.zeros(N)
-        #for i, word in enumerate(self.kmer_set.kmers):
+        # vector = np.zeros(N)
+        # for i, word in enumerate(self.kmer_set.kmers):
         #    vector[i] += kmer2count[word]
 
         # Convert to frequencies
@@ -311,5 +312,20 @@ class KmerVec:
 
         return vector
 
-    def harmonize_data(self, record, kmerlist):
-        return(self.basis.transform(record, kmerlist))
+    def harmonize(self, record, kmerlist):
+        """_summary_
+
+        Parameters
+        ----------
+        record : _type_
+            _description_
+        kmerlist : _type_
+            _description_
+
+        Returns
+        -------
+        _type_
+            _description_
+        """
+        return self.basis.transform(record, kmerlist)
+


### PR DESCRIPTION
Previous code throws a RuleException:
KeyError in line 162 [...] 'kmerlist is not a file in the archive'

This occurs because `snekmer.io.load_npz` had been modified to return a tuple of a DataFrame object and a list object, but the code had been incorrectly implemented such that the list object was not being correctly read from the input file. Note that npz objects in Snekmer no longer store lists of kmers / the kmer basis set, and thus have no 'kmerlist' object.

The code was updated to remove the second returned item from `snekmer.io.load_npz` (thus, only a DataFrame is returned, as before) and the code in `cluster.smk` no longer relies on this function to pull the kmerlist. Instead, the kmer basis object is loaded separately and read to obtain the kmers.