### PR TITLE
[v1.0.1] Update `rules.common_basis`. Bugfix for `rules.unzip`

### DIFF
--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -18,12 +18,7 @@ score:
 # cluster params
 cluster:
   method: "agglomerative"
-  params:
-    {
-      n_clusters: None,
-      distance_threshold: 95,
-      linkage: ward,
-    }
+  params: { n_clusters: None, distance_threshold: 95, linkage: ward }
   cluster_plots: True
 
   # clustering distance matrix params

--- a/snekmer/io.py
+++ b/snekmer/io.py
@@ -86,7 +86,7 @@ def load_npz(
     return pd.DataFrame(df)
 
 
-def read_output_kmers(filename: str) -> List[str]:
+def read_kmers(filename: str) -> List[str]:
     """Extract kmer identifiers from Snekmer output file.
 
     Parameters
@@ -103,12 +103,13 @@ def read_output_kmers(filename: str) -> List[str]:
     kmers = list()
     with open(filename) as f:
         for line in f:
-            line_data = line.split("\t")
+            kmers.append(line.strip())  # .split("\t")
             # parse kmer outputs if detected
-            if re.findall(r"^KMER", line_data[0]):
-                kmers += line_data
-    prefix = re.search(r"^KMER-[\d]+-[A-Za-z]+-", kmers[0]).group()
-    return [s.strip().replace(prefix, "") for s in kmers]
+            # if re.findall(r"^KMER", line_data[0]):
+            # kmers += line_data
+    # prefix = re.search(r"^KMER-[\d]+-[A-Za-z]+-", kmers[0]).group()
+    # return [s.strip().replace(prefix, "") for s in kmers]
+    return kmers
 
 
 def vecfiles_to_df(

--- a/snekmer/rules/cluster.smk
+++ b/snekmer/rules/cluster.smk
@@ -166,7 +166,7 @@ rule cluster:
             # basis.extend(klist)
 
         # make a superset of kmers
-        kmerbasis = np.unique(kmers)
+        kmerbasis = np.unique(np.hstack(kmers))
         basis = skm.vectorize.KmerVec(config["alphabet"], config["k"])
         basis.set_kmer_set(kmerbasis)
 

--- a/snekmer/rules/process.smk
+++ b/snekmer/rules/process.smk
@@ -23,6 +23,8 @@ rule unzip:
         zipped=join("input", "zipped", "{uz}.gz"),
     run:
         # preserve zipped file
+        if not exists(dirname(output.zipped)):
+            makedirs(dirname(output.zipped))
         copy(input[0], output.zipped)
 
         # unzip and save file contents

--- a/snekmer/vectorize.py
+++ b/snekmer/vectorize.py
@@ -134,7 +134,19 @@ class KmerSet:
     """Given alphabet and k, creates iterator for kmer basis set.
     """
 
-    def __init__(self, alphabet: Union[str, int], k: int, kmerlist: list = list()):
+    def __init__(self, alphabet: Union[str, int], k: int, kmers: list = None):
+        """Initialize KmerSet object
+
+        Parameters
+        ----------
+        alphabet : Union[str, int]
+            Alphabet name or identifier
+        k : int
+            Kmer length
+        kmers : list, optional
+            List of kmers to manually specify basis set, by default None
+
+        """
         self.alphabet = alphabet
         self.k = k
 
@@ -145,10 +157,11 @@ class KmerSet:
         #              into this problem. Only populate those
         #              kmers that exist. I think this was crashing
         #              my computer with a k=8 alphabet=5
-        if len(kmerlist) == 0:
+
+        if kmers is None:
             self._kmerlist = list(_generate(get_alphabet_keys(alphabet), k))
         else:
-            self._kmerlist = kmerlist
+            self._kmerlist = kmers
 
     @property
     def kmers(self):


### PR DESCRIPTION
Minor changes to v1.0.0, including:

- Changes to the common basis filename and filetype (note: this is probably the least important change and open to reversion/future modification)
- Changes to how common basis kmers are collated (using built-in set vs. numpy.unique); should work better when multiple large kmer sets are combined.
- Bugfix for the unzip rule, in which the needed output directories were not being created as expected.