### PR TITLE
[report] Fix directory explorer link in model report

### DIFF
--- a/snekmer/rules/model.smk
+++ b/snekmer/rules/model.smk
@@ -468,6 +468,7 @@ rule model_report:
                 f"({config['model']['cv']}-Fold Cross-Validation) "
                 f"are below."
             ),
+            dir=skm.report.correct_rel_path(tab_dir)
         )
 
         skm.report.create_report_many_images(


### PR DESCRIPTION
Resolves a minor bug in the model report where the link to the file explorer directory was not defined, and thus would not link correctly.