### PR TITLE
[docs] Add CLI options to docs via `sphinx-argparse`. Update FAQs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,11 +10,12 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
-import sphinx_rtd_theme
+import os
+import sys
 
+sys.path.insert(0, os.path.abspath("../../"))
+
+import sphinx_rtd_theme
 
 # -- Project information -----------------------------------------------------
 
@@ -24,13 +25,37 @@ copyright = (
 )
 author = "C. H. Chang, W. C. Nelson, and J. E. McDermott"
 
+# import snekmer
+
+# # The version info for the project you're documenting, acts as replacement for
+# # |version| and |release|, also used in various other places throughout the
+# # built documents.
+# #
+# # The short X.Y version.
+# version = snekmer.__version__
+
+# if os.environ.get("READTHEDOCS") == "True":
+#     # Because Read The Docs modifies conf.py, versioneer gives a "dirty"
+#     # version like "5.10.0+0.g28674b1.dirty" that is cleaned here.
+#     version = version.partition("+0.g")[0]
+
+# # The full version, including alpha/beta/rc tags.
+# release = version
+
 
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx_rtd_theme", "sphinx_copybutton", "sphinxcontrib.bibtex", "nbsphinx"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx_rtd_theme",
+    "sphinx_copybutton",
+    "sphinxcontrib.bibtex",
+    "nbsphinx",
+    "sphinxarg.ext",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -39,6 +64,45 @@ templates_path = ["_templates"]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# autodoc_mock_imports = ["pandas", "snakemake"]
+
+# In lieu of autodoc_mock_imports (not compatible with sphinx-argparse),
+# use mock to consolidate pkg requirements for autodoc parsing
+import mock
+
+MOCK_MODULES = [
+    "Bio",
+    "hdbscan",
+    "matplotlib",
+    "matplotlib.pyplot",
+    "numba",
+    "numpy",
+    "numpy.typing",
+    "pandas",
+    "scipy",
+    "scipy.cluster.hierarchy",
+    "scipy.spatial.distance",
+    "seaborn",
+    "sklearn",
+    "sklearn.base",
+    "sklearn.cluster",
+    "sklearn.decomposition",
+    "sklearn.ensemble",
+    "sklearn.linear_model",
+    "sklearn.manifold",
+    "sklearn.metrics",
+    "sklearn.metrics.pairwise",
+    "sklearn.model_selection",
+    "sklearn.pipeline",
+    "sklearn.preprocessing",
+    "sklearn.svm",
+    "sklearn.tree",
+    "snakemake",
+    "umap",
+]
+for mod_name in MOCK_MODULES:
+    sys.modules[mod_name] = mock.Mock()
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -68,3 +132,9 @@ bibtex_bibfiles = ["refs.bib"]
 bibtex_encoding = "latin"
 bibtex_default_style = "unsrt"
 
+# -- Argparse setup ----------------------------------------------------------
+def setup(app):
+    app.add_css_file("sphinx-argparse.css")
+
+
+rst_epilog = f".. |mock_modules| replace:: {MOCK_MODULES}"

--- a/docs/source/getting_started/cli.rst
+++ b/docs/source/getting_started/cli.rst
@@ -74,3 +74,13 @@ step, run:
 .. code-block:: bash
 
     snekmer {mode} --until vectorize
+
+.. _getting_started-all_options:
+
+All Options
+-----------
+
+.. argparse::
+   :module: snekmer.cli
+   :func: get_main_args
+   :prog: snekmer

--- a/docs/source/getting_started/usage.rst
+++ b/docs/source/getting_started/usage.rst
@@ -77,7 +77,7 @@ Mode-Specific Output Files
 The steps in the Snekmer pipeline generate their own associated output files.
 
 Snekmer Cluster Output Files
-............................
+::::::::::::::::::::::::::::
 
 Snekmer's cluster mode produces the following output files
 and directories in addition to the files described previously.
@@ -95,7 +95,7 @@ and directories in addition to the files described previously.
                 └── umap.png
 
 Snekmer Model Output Files
-..........................
+::::::::::::::::::::::::::
 
 Snekmer's model mode produces the following output files
 and directories in addition to the files described previously.
@@ -124,7 +124,7 @@ and directories in addition to the files described previously.
                 └── B/
 
 Snekmer Search Output Files
-...........................
+:::::::::::::::::::::::::::
 
 The ``snekmer search`` mode assumes that the user has pre-generated
 family models using the ``snekmer model`` workflow, and thus operates

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,7 +1,9 @@
 sphinx >=5
+sphinx-argparse
 sphinx-rtd-theme
 sphinx-copybutton
 sphinxcontrib-bibtex
+mock
 nbsphinx
 nbconvert==7.2.1
 mistune>=2

--- a/docs/source/troubleshooting/common.rst
+++ b/docs/source/troubleshooting/common.rst
@@ -2,7 +2,8 @@ Frequently Asked Questions
 ==========================
 
 Some commonly encountered questions are addressed here. For more
-detailed or specific questions, feel free to `submit an issue on Github <https://github.com/PNNL-CompBio/Snekmer/issues>`_.
+detailed or specific questions that have not been included below, feel free to
+`submit an issue on Github <https://github.com/PNNL-CompBio/Snekmer/issues>`_.
 
 Installation Questions
 ----------------------
@@ -30,16 +31,47 @@ followed by ``conda list``, to check that the environment was
 created successfully and that Snekmer was indeed installed.
 
 
-Usage Questions
----------------
+Troubleshooting Error Messages
+------------------------------
 
-Why I am encountering a ``MissingInputException`` when I try to run Snekmer?
-````````````````````````````````````````````````````````````````````````````
+MissingInputException
+`````````````````````
 
 Typically, this means that Snekmer is unable to detect input files,
 and the input files may not follow the required directory structure.
 For more information, including an example of the file structure
 needed, see :ref:`getting_started-configuration`.
+
+/bin/sh: line 0: cd: {PATH}: No such file or directory
+``````````````````````````````````````````````````````
+
+This is a `known issue with Snakemake v7.3.0+ <https://github.com/snakemake/snakemake/issues/1546>`_.
+Check your Snakemake version and reinstall a lower version if necessary
+(we recommend Snakemake v7.0).
+
+FileNotFoundError
+`````````````````
+
+This error usually indicates that the file system latency is not
+sufficiently long. In order words, the system is taking longer to
+create the file than Snakemake is allotting to wait for the file to
+be created. To troubleshoot this issue, we recommend increasing
+the ``--latency`` parameter (see :ref:`getting_started-all_options`).
+The default is set to 30 seconds, but the parameter can be adjusted
+to suit your individual system.
+
+General Usage Questions
+-----------------------
+
+My logs are very long, resulting in large log file sizes. How can I reduce this?
+````````````````````````````````````````````````````````````````````````````````
+
+By default, Snekmer logs all Snakemake output, including construction of the DAG
+and information about individual jobs. However, the default settings will produce
+very big log files if several files are being evaluated at once. To reduce the
+verbosity of output logs, we recommend invoking the ``--quiet`` parameter
+(see :ref:`getting_started-all_options`).
+
 
 Snekmer model mode is not working.
 ``````````````````````````````````

--- a/docs/source/troubleshooting/common.rst
+++ b/docs/source/troubleshooting/common.rst
@@ -34,6 +34,12 @@ created successfully and that Snekmer was indeed installed.
 Troubleshooting Error Messages
 ------------------------------
 
+If you encounter an error while using Snekmer, we recommend first
+checking the `Snakemake FAQs page <https://snakemake.readthedocs.io/en/stable/project_info/faq.html>`_
+for a solution. We have also listed some common error messages below.
+If your error message cannot be solved, feel free to let us know via
+`Github issues <https://github.com/PNNL-CompBio/Snekmer/issues>`_.
+
 MissingInputException
 `````````````````````
 
@@ -41,13 +47,6 @@ Typically, this means that Snekmer is unable to detect input files,
 and the input files may not follow the required directory structure.
 For more information, including an example of the file structure
 needed, see :ref:`getting_started-configuration`.
-
-/bin/sh: line 0: cd: {PATH}: No such file or directory
-``````````````````````````````````````````````````````
-
-This is a `known issue with Snakemake v7.3.0+ <https://github.com/snakemake/snakemake/issues/1546>`_.
-Check your Snakemake version and reinstall a lower version if necessary
-(we recommend Snakemake v7.0).
 
 FileNotFoundError
 `````````````````
@@ -59,6 +58,22 @@ be created. To troubleshoot this issue, we recommend increasing
 the ``--latency`` parameter (see :ref:`getting_started-all_options`).
 The default is set to 30 seconds, but the parameter can be adjusted
 to suit your individual system.
+
+/bin/sh: line 0: cd: {PATH}: No such file or directory
+``````````````````````````````````````````````````````
+
+This is a `known issue with Snakemake v7.3.0+ <https://github.com/snakemake/snakemake/issues/1546>`_.
+Check your Snakemake version and reinstall a lower version if necessary
+(we recommend Snakemake v7.0).
+
+Error: Directory cannot be locked.
+``````````````````````````````````
+The full error message should provide further instructions, but this
+error will appear when Snekmer has been unexpectedly terminated.
+Run ``snekmer {mode} --unlock`` (note: this command will not execute the
+workflow) before rerunning the workflow.
+
+If the error persists, delete the ``.snakemake`` directory and try again.
 
 General Usage Questions
 -----------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@
 # matplotlib
 # numpy >= 1.22.3
 # numba >= 0.56
+# pandas
+# seaborn
 # scipy
 # scikit-learn
 # snakemake == 7.0

--- a/snekmer/cli.py
+++ b/snekmer/cli.py
@@ -191,6 +191,31 @@ def get_argument_parser():
             "the snakefile will use this as their origin)."
         ),
     )
+    parser["smk"].add_argument(
+        "--forcerun",
+        "-R",
+        nargs="*",
+        metavar="TARGET",
+        help=(
+            "Force the re-execution or creation of the given rules or files."
+            " Use this option if you changed a rule and want to have all its "
+            "output in your workflow updated."
+        ),
+    )
+    parser["smk"].add_argument(
+        "--list-code-changes",
+        "--lc",
+        action="store_true",
+        help="List all output files for which the rule body (run or shell) have "
+        "changed in the Snakefile.",
+    )
+    parser["smk"].add_argument(
+        "--list-params-changes",
+        "--lp",
+        action="store_true",
+        help="List all output files for which the defined params have changed "
+        "in the Snakefile.",
+    )
 
     # clust execution options
     parser["clust"] = parser["smk"].add_argument_group("Cluster Execution Arguments")
@@ -278,11 +303,14 @@ def main():
             cluster=cluster,
             keepgoing=args.keepgoing,
             force_incomplete=True,
+            forcerun=args.forcerun,
             cores=args.cores,
             nodes=args.jobs,
             workdir=args.directory,
             dryrun=args.dryrun,
             unlock=args.unlock,
+            list_code_changes=args.list_code_changes,
+            list_params_changes=args.list_params_changes,
             until=args.until,
             touch=args.touch,
             latency_wait=args.latency,
@@ -299,11 +327,14 @@ def main():
             cluster=cluster,
             keepgoing=args.keepgoing,
             force_incomplete=True,
+            forcerun=args.forcerun,
             cores=args.cores,
             nodes=args.jobs,
             workdir=args.directory,
             dryrun=args.dryrun,
             unlock=args.unlock,
+            list_code_changes=args.list_code_changes,
+            list_params_changes=args.list_params_changes,
             until=args.until,
             touch=args.touch,
             latency_wait=args.latency,
@@ -320,11 +351,14 @@ def main():
             cluster=cluster,
             keepgoing=True,
             force_incomplete=True,
+            forcerun=args.forcerun,
             cores=args.cores,
             nodes=args.jobs,
             workdir=args.directory,
             dryrun=args.dryrun,
             unlock=args.unlock,
+            list_code_changes=args.list_code_changes,
+            list_params_changes=args.list_params_changes,
             until=args.until,
             touch=args.touch,
             latency_wait=args.latency,

--- a/snekmer/cli.py
+++ b/snekmer/cli.py
@@ -1,6 +1,6 @@
 """cli: Command line interface for Snekmer.
 
-author: @christinehc, @biodataganache
+author: @christinehc, @biodataganache, @snakemake
 
 """
 # imports
@@ -23,31 +23,51 @@ MAP_FN_DESC = [
 MAP_FNS = {f"reduced_alphabet_{n}": MAP_FN_DESC[n] for n in range(5)}
 
 
-def main():
+def get_argument_parser():
     parser = {}
 
     # main parser
     parser["main"] = argparse.ArgumentParser(
-        description="Snekmer: A tool for kmer-based sequence analysis using amino acid reduction (AAR)"
+        description=(
+            "Snekmer: A tool for kmer-based sequence analysis"
+            " using amino acid reduction (AAR)."
+        )
     )
     parser["main"].add_argument(
         "-v",
         "--version",
         action="version",
         version=__version__,
-        help="print version and exit",
+        help="Print version and exit.",
     )
 
-    # snakemake options
+    # Snakemake options
+    # NOTE: Arguments and documentation borrowed from Snakemake:
+    # https://github.com/snakemake/snakemake/blob/main/snakemake/__init__.py
     parser["smk"] = argparse.ArgumentParser(add_help=False)
     parser["smk"].add_argument(
-        "--dryrun", "-n", action="store_true", help="perform a dry run"
+        "--dry-run",
+        "--dryrun",
+        "-n",
+        dest="dryrun",
+        action="store_true",
+        help="Do not execute anything, and display what would be done. "
+        "If you have a very large workflow, use --dry-run --quiet to just "
+        "print a summary of the DAG of jobs.",
     )
     parser["smk"].add_argument(
         "--configfile",
-        metavar="PATH",
-        default="config.yaml",
-        help="path to yaml configuration file",
+        "--configfiles",
+        nargs="+",
+        metavar="FILE",
+        help=(
+            "Specify or overwrite the config file of the workflow (see the docs). "
+            "Values specified in JSON or YAML format are available in the global config "
+            "dictionary inside the workflow. Multiple files overwrite each other in "
+            "the given order. Thereby missing keys in previous config files are extended by "
+            "following configfiles. Note that this order also includes a config file defined "
+            "in the workflow definition itself (which will come first)."
+        ),
     )
     parser["smk"].add_argument(
         "-C",
@@ -65,59 +85,88 @@ def main():
     )
     parser["smk"].add_argument("--unlock", action="store_true", help="unlock directory")
     parser["smk"].add_argument(
-        "-U",
         "--until",
-        metavar="TARGET",
+        "-U",
         nargs="+",
-        help="run pipeline until reaching the target rule or files",
+        metavar="TARGET",
+        help=(
+            "Runs the pipeline until it reaches the specified rules or "
+            "files. Only runs jobs that are dependencies of the specified "
+            "rule or files, does not run sibling DAGs. "
+        ),
     )
     parser["smk"].add_argument(
         "--keepgoing",
         "--keep-going",
         "-k",
         action="store_true",
-        default=False,
-        help="go on with independent jobs if a job fails",
+        help="Go on with independent jobs if a job fails.",
     )
     parser["smk"].add_argument(
         "--latency",
         "-w",
         "--output-wait",
         "--latency-wait",
-        metavar="SECONDS",
         type=int,
         default=30,
-        help="wait time, in seconds, for output file creation (default 30)",
+        metavar="SECONDS",
+        help="Wait given seconds if an output file of a job is not present after "
+        "the job finished. This helps if your filesystem "
+        "suffers from latency (default 30).",
     )
     parser["smk"].add_argument(
-        "--touch", action="store_true", help="touch output files only"
+        "--touch",
+        "-t",
+        action="store_true",
+        help=(
+            "Touch output files (mark them up to date without really "
+            "changing them) instead of running their commands. This is "
+            "used to pretend that the rules were executed, in order to "
+            "fool future invocations of snakemake. Fails if a file does "
+            "not yet exist. Note that this will only touch files that would "
+            "otherwise be recreated by Snakemake (e.g. because their input "
+            "files are newer). For enforcing a touch, combine this with "
+            "--force, --forceall, or --forcerun. Note however that you loose "
+            "the provenance information when the files have been created in "
+            "realitiy. Hence, this should be used only as a last resort."
+        ),
     )
     parser["smk"].add_argument(
-        "-c",
         "--cores",
+        "-c",
+        action="store",
+        const=cpu_count(),
+        nargs="?",
         metavar="N",
-        type=int,
-        default=cpu_count(),
-        help="number of cores used for execution (local execution only)",
+        help=(
+            "Use at most N CPU cores/jobs in parallel. "
+            "If N is omitted or 'all', the limit is set to the number of "
+            "available CPU cores. "
+            "In case of cluster/cloud execution, this argument sets the maximum number "
+            "of cores requested from the cluster or cloud scheduler. (See "
+            "https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#"
+            "resources-remote-execution for more info)"
+            "This number is available to rules via workflow.cores."
+        ),
     )
     parser["smk"].add_argument(
         "--count",
         metavar="N",
         type=int,
-        help="number of files to process (limits DAG size)",
+        help="Number of files to process (limits DAG size).",
     )
     parser["smk"].add_argument(
         "--countstart",
         metavar="IDX",
         type=int,
         default=0,
-        help="starting file index (for use with --count)",
+        help="Starting file index (for use with --count).",
     )
     parser["smk"].add_argument(
         "--verbose",
         action="store_true",
         default=False,
-        help="show additional debug output (default False)",
+        help="Show additional debug output (default False)",
     )
     parser["smk"].add_argument(
         "--quiet",
@@ -144,11 +193,11 @@ def main():
     )
 
     # clust execution options
-    parser["clust"] = parser["smk"].add_argument_group("cluster execution arguments")
+    parser["clust"] = parser["smk"].add_argument_group("Cluster Execution Arguments")
     parser["clust"].add_argument(
         "--clust",
         metavar="PATH",
-        help="path to cluster execution yaml configuration file",
+        help="Path to cluster execution yaml configuration file.",
     )
     parser["clust"].add_argument(
         "-j",
@@ -156,31 +205,43 @@ def main():
         metavar="N",
         type=int,
         default=1000,
-        help="number of simultaneous jobs to submit to a slurm queue",
+        help="Number of simultaneous jobs to submit to a slurm queue.",
     )
 
     # create subparsers for each operation mode
     # parser.add_argument("mode", choices=["cluster", "model", "search"])
     parser["subparsers"] = parser["main"].add_subparsers(
-        title="mode", description="Snekmer mode", dest="mode"
+        title="mode",
+        description="Snekmer mode (cluster, model, or search).",
+        dest="mode",
     )
 
     # subparsers
     parser["cluster"] = parser["subparsers"].add_parser(
         "cluster",
-        description="Apply unsupervised clustering via Snekmer",
+        description="Apply unsupervised clustering via Snekmer.",
         parents=[parser["smk"]],
     )
     parser["model"] = parser["subparsers"].add_parser(
         "model",
-        description="Train supervised models via Snekmer",
+        description="Train supervised models via Snekmer.",
         parents=[parser["smk"]],
     )
     parser["search"] = parser["subparsers"].add_parser(
         "search",
-        description="Search sequences against pre-existing models via Snekmer",
+        description="Search sequences against pre-existing models via Snekmer.",
         parents=[parser["smk"]],
     )
+    return parser
+
+
+def get_main_args():
+    parser = get_argument_parser()
+    return parser["main"]
+
+
+def main():
+    parser = get_argument_parser()
 
     # parse args
     args = parser["main"].parse_args()
@@ -240,6 +301,7 @@ def main():
             force_incomplete=True,
             cores=args.cores,
             nodes=args.jobs,
+            workdir=args.directory,
             dryrun=args.dryrun,
             unlock=args.unlock,
             until=args.until,
@@ -260,6 +322,7 @@ def main():
             force_incomplete=True,
             cores=args.cores,
             nodes=args.jobs,
+            workdir=args.directory,
             dryrun=args.dryrun,
             unlock=args.unlock,
             until=args.until,


### PR DESCRIPTION
Changelog:
- 2 new FAQs have been added
- Docs pages now include all CLI options using `sphinx-argparse` for automatic parsing. (This adds `mock` as a dependency in order to bypass module imports.)
- requirements.txt was out of date and has been updated (though all requirements are currently commented out as they are not currently being used in the package setup)
- The CLI itself has been updated for better formatting of help messages and adherence to the Snakemake CLI (help messages, for instance, are now fully copied over).