### PR TITLE
Disable ability to specify more than 1 configuration file

### DIFF
--- a/snekmer/__init__.py
+++ b/snekmer/__init__.py
@@ -10,4 +10,4 @@ from . import report
 
 # from . import walk
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/snekmer/cli.py
+++ b/snekmer/cli.py
@@ -57,7 +57,6 @@ def get_argument_parser():
     )
     parser["smk"].add_argument(
         "--configfile",
-        nargs="+",
         metavar="PATH",
         help=(
             "Specify or overwrite the config file of the workflow (see the docs). "

--- a/snekmer/cli.py
+++ b/snekmer/cli.py
@@ -57,9 +57,8 @@ def get_argument_parser():
     )
     parser["smk"].add_argument(
         "--configfile",
-        "--configfiles",
         nargs="+",
-        metavar="FILE",
+        metavar="PATH",
         help=(
             "Specify or overwrite the config file of the workflow (see the docs). "
             "Values specified in JSON or YAML format are available in the global config "


### PR DESCRIPTION
Previous version had adapted code directly from the Snakemake API for the parameter ``configfiles`` which enabled any number of config files to be specified; however, this behavior is not compatible with the Snekmer CLI, resulting in ``AttributeError: __enter__``. The number of configuration files that may be specified on the command line has been restricted to 1 to resolve this error.