### PR TITLE
Enable nested directory output

### DIFF
--- a/snekmer/__init__.py
+++ b/snekmer/__init__.py
@@ -10,4 +10,4 @@ from . import report
 
 # from . import walk
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"

--- a/snekmer/io.py
+++ b/snekmer/io.py
@@ -8,6 +8,7 @@ import gzip
 import json
 import pickle
 import re
+from ast import literal_eval
 from os.path import basename, join, splitext
 from typing import Any, Dict, List, Optional, Union
 
@@ -49,7 +50,7 @@ def load_npz(
         "seqs": "sequence",
         "vecs": "sequence_vector",
     },
-    objects: tuple = ("kmerlist",)
+    objects: tuple = ("kmerlist",),
 ) -> pd.DataFrame:
     """Compile .npz results into dataframe.
 
@@ -181,6 +182,8 @@ def define_output_dir(alphabet: Union[str, int], k: int, nested: bool = False) -
         Name of output directory, given nested directory parameters.
 
     """
+    if isinstance(nested, str):
+        nested = literal_eval(nested)
     if not nested:
         return "output"
     if not isinstance(alphabet, str):

--- a/snekmer/rules/cluster.smk
+++ b/snekmer/rules/cluster.smk
@@ -115,10 +115,10 @@ use rule vectorize from kmerize with:
     input:
         fasta=lambda wildcards: join(input_dir, f"{wildcards.nb}.{FA_MAP[wildcards.nb]}"),
     output:
-        data=join("output", "vector", "{nb}.npz"),
-        kmerobj=join("output", "kmerize", "{nb}.kmers"),
+        data=join(out_dir, "vector", "{nb}.npz"),
+        kmerobj=join(out_dir, "kmerize", "{nb}.kmers"),
     log:
-        join("output", "kmerize", "log", "{nb}.log"),
+        join(out_dir, "kmerize", "log", "{nb}.log"),
 
 # [in-progress] kmer walk
 # if config['walk']:
@@ -134,9 +134,6 @@ rule cluster:
         data=expand(join("output", "vector", "{fa}.npz"), fa=NON_BGS),
     output:
         figs = directory(join(out_dir, "cluster", "figures")),
-        # pca=join(out_dir, "cluster", "figures", "pca_explained_variance_curve.png"),
-        # tsne=join(out_dir, "cluster", "figures", "tsne.png"),
-        # umap=join(out_dir, "cluster", "figures", "umap.png"),
         table=join(out_dir, "cluster", "snekmer.csv")
     log:
         join(out_dir, "cluster", "log", "cluster.log"),
@@ -342,9 +339,6 @@ rule cluster:
 rule cluster_report:
     input:
         figs=rules.cluster.output.figs,
-        # pca=rules.cluster.output.pca,
-        # tsne=rules.cluster.output.tsne,
-        # umap=rules.cluster.output.umap,
         table=rules.cluster.output.table
     output:
         join(out_dir, 'Snekmer_Cluster_Report.html')

--- a/snekmer/rules/model.smk
+++ b/snekmer/rules/model.smk
@@ -90,7 +90,7 @@ out_dir = skm.io.define_output_dir(
 rule all:
     input:
         expand(join("input", "{uz}"), uz=UZS),  # require unzipping
-        expand(join("output", "model", "{nb}.model"), nb=NON_BGS),  # require model-building
+        expand(join(out_dir, "model", "{nb}.model"), nb=NON_BGS),  # require model-building
         join(out_dir, 'Snekmer_Model_Report.html'),
 
 

--- a/snekmer/rules/model.smk
+++ b/snekmer/rules/model.smk
@@ -106,24 +106,24 @@ use rule vectorize from kmerize with:
     input:
         fasta=lambda wildcards: join("input", f"{wildcards.nb}.{FA_MAP[wildcards.nb]}"),
     output:
-        data=join("output", "vector", "{nb}.npz"),
-        kmerobj=join("output", "kmerize", "{nb}.kmers"),
+        data=join(out_dir, "vector", "{nb}.npz"),
+        kmerobj=join(out_dir, "kmerize", "{nb}.kmers"),
     log:
-        join("output", "kmerize", "log", "{nb}.log"),
+        join(out_dir, "kmerize", "log", "{nb}.log"),
 
 
 # build family score basis
 rule score:
     input:
-        kmerobj=join("output", "kmerize", "{nb}.kmers"),
-        data=expand(join("output", "vector", "{fa}.npz"), fa=NON_BGS),
+        kmerobj=join(out_dir, "kmerize", "{nb}.kmers"),
+        data=expand(join(out_dir, "vector", "{fa}.npz"), fa=NON_BGS),
     output:
-        data=join("output", "scoring", "sequences", "{nb}.csv.gz"),
-        weights=join("output", "scoring", "weights", "{nb}.csv.gz"),
-        scorer=join("output", "scoring", "{nb}.scorer"),
-        matrix=join("output", "scoring", "{nb}.matrix"),
+        data=join(out_dir, "scoring", "sequences", "{nb}.csv.gz"),
+        weights=join(out_dir, "scoring", "weights", "{nb}.csv.gz"),
+        scorer=join(out_dir, "scoring", "{nb}.scorer"),
+        matrix=join(out_dir, "scoring", "{nb}.matrix"),
     log:
-        join("output", "scoring", "log", "{nb}.log"),
+        join(out_dir, "scoring", "log", "{nb}.log"),
     run:
         # log script start time
         start_time = datetime.now()
@@ -249,9 +249,9 @@ rule model:
         kmerobj=rules.score.input.kmerobj,
         matrix=rules.score.output.matrix
     output:
-        model=join("output", "model", "{nb}.model"),
-        results=join("output", "model", "results", "{nb}.csv"),
-        figs=directory(join("output", "model", "figures", "{nb}")),
+        model=join(out_dir, "model", "{nb}.model"),
+        results=join(out_dir, "model", "results", "{nb}.csv"),
+        figs=directory(join(out_dir, "model", "figures", "{nb}")),
     run:
         # create lookup table to match vector to sequence by file+ID
         #lookup = {}
@@ -452,8 +452,8 @@ rule model:
 
 rule model_report:
     input:
-        results=expand(join("output", "model", "results", "{nb}.csv"), nb=NON_BGS),
-        figs=expand(join("output", "model", "figures", "{nb}"), nb=NON_BGS),
+        results=expand(join(out_dir, "model", "results", "{nb}.csv"), nb=NON_BGS),
+        figs=expand(join(out_dir, "model", "figures", "{nb}"), nb=NON_BGS),
     output:
         join(out_dir, 'Snekmer_Model_Report.html')
     run:


### PR DESCRIPTION
Changelog:

- `snekmer.io.define_output_dir` explicitly converts boolean input from config.yaml if read as strings. This causes the expected boolean input for the `nested` parameter to always read as True, as `"False"` is truthy. The behavior has been corrected via `ast.literal_eval` to force conversion of string representations to booleans.
- Files created by the cluster, model, and search rules have been changed back to accepting the defined output directory as the location of any created output files; previously, nested directory outputs were not allowed due to the aforementioned problem with defining the output directory structure from config.
- Version has been upticked to v1.0.3 accordingly.