### PR TITLE
[docs] Add Apple silicon / additional instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ and outputs a table for each file containing model annotation probabilities for 
 For installation instructions, documentation, and more, refer to
 the [official documentation](https://snekmer.readthedocs.io).
 
-Run the demonstration example code in:
-resources/tutorial/demo_example
+To run the demonstration example, see 
+[resources/tutorial/demo_example](https://github.com/PNNL-CompBio/Snekmer/tree/main/resources/tutorial/demo_example).
 
 ## Acknowledgments
 

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -120,8 +120,27 @@ To use the command line interface within the container:
   docker exec -it <container ID> /bin/bash
 
 
-Additional 'docker' commands could be used to copy data into the container or to mount it to a local directory.   
+Additional ``docker`` commands can be used to copy data into the container or to mount it to a local directory.
+
+The current version of the Docker image requires the ``--configfile`` flag
+to be called explicitly (see :ref:`getting_started-all_options`).
+
 **Note:** This container is designed to run indefinitely and should be stopped after use.
+
+Notes on Using Snekmer Docker Image with Apple Silicon (M1/M2 Mac) Systems
+``````````````````````````````````````````````````````````````````````````
+
+The current Docker image of Snekmer has not been built for compatibility with ARM64
+systems (e.g. Apple silicon systems with the Apple M1/M2 chip). To use the Docker image
+on an Apple silicon system, Rosetta 2 is required. See the
+`relevant Docker documentation page <https://docs.docker.com/desktop/install/mac-install/>`_
+for more information.
+
+Rosetta 2 can be installed on the command line using ``softwareupdate``:
+
+.. code-block:: bash
+
+  softwareupdate --install-rosetta
 
 
 (optional) Install GCC for BSF
@@ -169,6 +188,9 @@ shown below:
     export CPPFLAGS="-I/usr/local/opt/llvm/include"
 
 You may follow these instructions to ensure GCC is correctly pulled as needed.
+
+**Note:** BSF is not compatible with Apple silicon systems; see the ongoing log
+of `known Apple silicon issues <https://github.com/PNNL-CompBio/Snekmer/issues/60>`_.
 
 Windows or Linux/Unix
 `````````````````````

--- a/docs/source/troubleshooting/common.rst
+++ b/docs/source/troubleshooting/common.rst
@@ -54,10 +54,22 @@ If your error message cannot be solved, feel free to let us know via
 MissingInputException
 `````````````````````
 
-Typically, this means that Snekmer is unable to detect input files,
+Non-Windows Systems
+:::::::::::::::::::
+
+Generally, this error type means that Snekmer is unable to detect input files,
 and the input files may not follow the required directory structure.
 For more information, including an example of the file structure
 needed, see :ref:`getting_started-configuration`.
+
+Windows Systems
+:::::::::::::::
+
+For Windows systems specifically, there is a `known issue <https://github.com/PNNL-CompBio/Snekmer/issues/60>`_
+with handling unzipping files that will raise a ``MissingInputException``
+and cause Snekmer to terminate under failure. We are aware of this issue
+and are actively working on a resolution; in the meantime, we recommend
+separately unzipping any zipped files prior to evaluation via Snekmer.
 
 FileNotFoundError
 `````````````````
@@ -97,7 +109,6 @@ and information about individual jobs. However, the default settings will produc
 very big log files if several files are being evaluated at once. To reduce the
 verbosity of output logs, we recommend invoking the ``--quiet`` parameter
 (see :ref:`getting_started-all_options`).
-
 
 Snekmer model mode is not working.
 ``````````````````````````````````

--- a/resources/README.md
+++ b/resources/README.md
@@ -12,5 +12,15 @@ The example YAML files included are:
 
 ## Tutorials
 
-The `tutorial` folder contains Jupyter notebooks outlining certain aspects
-of Snekmer.
+The `tutorial` folder contains a Jupyter notebook outlining certain aspects
+of Snekmer, as well as a folder containing example files with code to run
+a demo example.
+
+### Demonstration Example
+
+To run the demo example, run the
+[demo example code](https://github.com/PNNL-CompBio/Snekmer/tree/main/resources/tutorial/demo_example):
+
+```bash
+bash run_demo.sh
+```


### PR DESCRIPTION
Changelog:
- Add Windows zip/unzip issue to docs (#60)
- Add Docker instructions for Apple silicon compatibility (#102)
- Add notes for BSF incompatibility with Apple silicon (#102)
- Specify `bash` command must be called to run demo example