### PR TITLE
docs: change base class for SnekmerModel

### DIFF
--- a/snekmer/model.py
+++ b/snekmer/model.py
@@ -36,7 +36,7 @@ NAME2MODEL = {
 
 
 # classification models for protein families
-class SnekmerModel(ClassifierMixin, BaseEstimator):
+class SnekmerModel(BaseEstimator):
     """Classify a protein family using kmer vectors as input.
 
     Attributes


### PR DESCRIPTION
changelog:
- remove `ClassifierMixin` in `SnekmerModel` instantiation to resolve `TypeError: metaclass` conflict when building docs in sphinx: metaclass conflict
  - `SnekmerModel` now instantiates as a `BaseEstimator` only