### PR TITLE
Pinned `scikit-learn` version

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -10,4 +10,4 @@ mistune>=2
 biopython
 numpy >= 1.22.3
 snakemake >= 6.0
-scikit-learn
+scikit-learn < 1.2

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - scipy
   - pandas == 1.4.2
   - seaborn
-  - scikit-learn
+  - scikit-learn < 1.2
   - snakemake == 7.0
   - tabulate == 0.8.10
   - umap-learn

--- a/environment_BSF.yml
+++ b/environment_BSF.yml
@@ -15,7 +15,7 @@ dependencies:
   - scipy
   - pandas
   - seaborn
-  - scikit-learn
+  - scikit-learn < 1.2
   - snakemake == 7.0
   - tabulate == 0.8.10
   - umap-learn

--- a/environment_Windows.yml
+++ b/environment_Windows.yml
@@ -15,7 +15,7 @@ dependencies:
   - scipy
   - pandas
   - seaborn
-  - scikit-learn
+  - scikit-learn < 1.2
   - snakemake-minimal == 7.0
   - tabulate == 0.8.10
   - umap-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,8 @@ numba >= 0.56
 pandas == 1.4.2
 seaborn
 scipy
-scikit-learn
+scikit-learn < 1.2
 snakemake == 7.0
-scikit-learn
 tabulate == 0.8.10
 umap-learn
 hdbscan


### PR DESCRIPTION
Closes #128; an older version of `scikit-learn` needed to be pinned to circumvent the error `TypeError: AgglomerativeClustering.__init__() got an unexpected keyword argument 'affinity'`