### PR TITLE
Updates to Continuous Integration

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -35,20 +35,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Build test environment
         uses: conda-incubator/setup-miniconda@v2
         with:
           mamba-version: "*"
           channels: anaconda,conda-forge,bioconda,numba
-          auto-activate-base: false
           environment-file: .test/test-env.yml
+          activate-environment: snekmer
+          auto-activate-base: false
       - shell: bash -l {0}
         run: |
           conda info
           conda list
           conda config --show
-      - shell: bash -l {0}
-        run: mamba env create -f .test/test-env.yml
+          conda env list
+      # - shell: bash -l {0}
+      #   run: mamba env create -f .test/test-env.yml
       # - shell: bash -l {0}
       #   run: pip install -e git+https://github.com/PNNL-CompBio/Snekmer@learn_decoy_implementation#egg=snekmer
 

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -52,7 +52,7 @@ jobs:
       - shell: bash -l {0}
         run: mamba install -y -c conda-forge snakemake==7.0 tabulate==0.8.10
       - shell: bash -l {0}
-        run: pip install -e git+https://github.com/PNNL-CompBio/Snekmer@functionmotifs#egg=snekmer
+        run: pip install -e git+https://github.com/PNNL-CompBio/Snekmer@learn_decoy_implementation#egg=snekmer
 
       #test clustering step
       - name: Snekmer Cluster

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -42,6 +42,7 @@ jobs:
           mamba-version: "*"
           channels: anaconda,conda-forge,bioconda,numba
           environment-file: .test/test-env.yml
+          activate-environment: snekmer
           auto-activate-base: false
       - shell: bash -l {0}
         run: |

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -41,18 +41,17 @@ jobs:
         with:
           mamba-version: "*"
           channels: anaconda,conda-forge,bioconda,numba
-          auto-activate-base: false
-          activate-environment: snekmer
           environment-file: .test/test-env.yml
+          auto-activate-base: false
       - shell: bash -l {0}
         run: |
           conda info
           conda list
           conda config --show
-      - shell: bash -l {0}
-        run: mamba install -y -c conda-forge snakemake==7.0 tabulate==0.8.10
-      - shell: bash -l {0}
-        run: pip install -e git+https://github.com/PNNL-CompBio/Snekmer@learn_decoy_implementation#egg=snekmer
+      # - shell: bash -l {0}
+      #   run: mamba create -y -n snekmer
+      # - shell: bash -l {0}
+      #   run: pip install -e git+https://github.com/PNNL-CompBio/Snekmer@learn_decoy_implementation#egg=snekmer
 
       #test clustering step
       - name: Snekmer Cluster

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -41,8 +41,6 @@ jobs:
         with:
           mamba-version: "*"
           channels: anaconda,conda-forge,bioconda,numba
-          environment-file: .test/test-env.yml
-          activate-environment: snekmer
           auto-activate-base: false
       - shell: bash -l {0}
         run: |
@@ -50,6 +48,19 @@ jobs:
           conda list
           conda config --show
           conda env list
+      - name: Create snekmer environment from YAML
+        shell: bash -l {0}
+        run: |
+          # Always (re)create; safe because mamba skips work if identical
+          mamba env create -n snekmer -f .test/test-env.yml --yes
+      - name: Show conda info
+        shell: bash -l {0}
+        run: |
+          source activate snekmer
+          conda info
+          conda list | head
+          conda env list
+
       # - shell: bash -l {0}
       #   run: mamba env create -f .test/test-env.yml
       # - shell: bash -l {0}

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   # apply formating and linting
   Format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Apply snakefmt
@@ -25,7 +25,7 @@ jobs:
 
   # run all tests
   Test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - Format
 
@@ -93,9 +93,7 @@ jobs:
           export PATH="/usr/share/miniconda/bin:$PATH"
           source activate snekmer
           snekmer learn --configfile .test/config_learnapp.yaml -d .test --cores 1
-          mkdir .test/counts .test/confidence
-          mv .test/output/learn/kmer-counts-total.csv .test/counts/kmer-counts-total.csv
-          mv .test/output/eval_conf/global-confidence-scores.csv .test/confidence/global-confidence-scores.csv
+          mv .test/output/apply_inputs/* .test
           rm -rf .test/output
         
       # run Snekmer Learn against previously generated counts files

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -49,8 +49,8 @@ jobs:
           conda info
           conda list
           conda config --show
-      # - shell: bash -l {0}
-      #   run: mamba create -y -n snekmer
+      - shell: bash -l {0}
+        run: mamba env create -f .test/test-env.yml
       # - shell: bash -l {0}
       #   run: pip install -e git+https://github.com/PNNL-CompBio/Snekmer@learn_decoy_implementation#egg=snekmer
 

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -35,7 +35,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
       - name: Build test environment
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -43,8 +42,6 @@ jobs:
           channels: anaconda,conda-forge,bioconda,numba
           auto-activate-base: false
           environment-file: .test/test-env.yml
-          # activate-environment: snekmer
-          auto-activate-base: false
       - shell: bash -l {0}
         run: |
           conda info

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -51,12 +51,11 @@ jobs:
       - name: Create snekmer environment from YAML
         shell: bash -l {0}
         run: |
-          # Always (re)create; safe because mamba skips work if identical
           mamba env create -n snekmer -f .test/test-env.yml --yes
       - name: Show conda info
         shell: bash -l {0}
         run: |
-          source activate snekmer
+          conda activate snekmer
           conda info
           conda list | head
           conda env list
@@ -65,8 +64,6 @@ jobs:
       #   run: mamba env create -f .test/test-env.yml
       # - shell: bash -l {0}
       #   run: pip install -e git+https://github.com/PNNL-CompBio/Snekmer@learn_decoy_implementation#egg=snekmer
-
-
 
       #test clustering step
       - name: Snekmer Cluster

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -41,8 +41,9 @@ jobs:
         with:
           mamba-version: "*"
           channels: anaconda,conda-forge,bioconda,numba
+          auto-activate-base: false
           environment-file: .test/test-env.yml
-          activate-environment: snekmer
+          # activate-environment: snekmer
           auto-activate-base: false
       - shell: bash -l {0}
         run: |
@@ -53,6 +54,8 @@ jobs:
         run: mamba env create -f .test/test-env.yml
       # - shell: bash -l {0}
       #   run: pip install -e git+https://github.com/PNNL-CompBio/Snekmer@learn_decoy_implementation#egg=snekmer
+
+
 
       #test clustering step
       - name: Snekmer Cluster

--- a/.test/config_learnapp.yaml
+++ b/.test/config_learnapp.yaml
@@ -42,7 +42,7 @@ model_dir: "/path/to/output/model/"
 basis_dir: "/path/to/output/kmerize/"
 score_dir: "/path/to/output/scoring/"
 
-# learnapp params 
+
 learnapp:
   save_apply_associations: False
   fragmentation: False
@@ -52,3 +52,7 @@ learnapp:
   location: random
   seed: 999
   conf_weight_modifier: 20
+  selection: 'top_hit'  
+  threshold: 'Median'                  # Column name from family_summary_stats.csv
+  weight_top: 0.7                      # For combined_distance selection method
+  weight_distance: 0.3                 # For combined_distance selection method

--- a/.test/test-env.yml
+++ b/.test/test-env.yml
@@ -23,4 +23,4 @@ dependencies:
   - tabulate=0.8.10
   - pip
   - pip:
-      - git+https://github.com/PNNL-CompBio/Snekmer@learn_decoy_implementation#egg=snekmer
+      - git+https://github.com/PNNL-CompBio/Snekmer#egg=snekmer

--- a/.test/test-env.yml
+++ b/.test/test-env.yml
@@ -1,25 +1,25 @@
 name: snekmer
 channels:
+  - conda-forge
   - anaconda
   - bioconda
   - numba
-  - conda-forge
 dependencies:
-  - python == 3.10
+  - python=3.10
   - biopython
   - jinja2
   - mamba
   - pyarrow
   - matplotlib
-  - numpy == 1.22.3
-  - numba >= 0.56
+  - numpy=1.22.3
+  - numba>=0.56
   - scipy
-  - pandas == 1.4.2
+  - pandas=1.4.2
   - seaborn
   - scikit-learn
-  # - snakemake == 7.0
+  - snakemake=7.0
   - umap-learn
   - hdbscan
-  # - pip
-  # - pip:
-  #     - -e git+https://github.com/PNNL-CompBio/Snekmer#egg=snekmer
+  - pip
+  - pip:
+      - git+https://github.com/PNNL-CompBio/Snekmer@learn_decoy_implementation#egg=snekmer

--- a/.test/test-env.yml
+++ b/.test/test-env.yml
@@ -20,6 +20,7 @@ dependencies:
   - snakemake=7.0
   - umap-learn
   - hdbscan
+  - tabulate=0.8.10
   - pip
   - pip:
       - git+https://github.com/PNNL-CompBio/Snekmer@learn_decoy_implementation#egg=snekmer


### PR DESCRIPTION
Update 1: The current runner (ubuntu container) in the actions is longer in use (Github removed it). So this replaces it with a newer version.

Update 2: Fixes for conda environment build to work with the slightly different new runner.

Update 3: Updated the tests, config and annotation file for Learn/Apply - This is updated/confirmed to work when pinning the install to the learn_decoy_implementation branch, so merge this, check that tests pass for #127, then merge #127.